### PR TITLE
fix concurrent database access with multiple instances

### DIFF
--- a/paldb/src/main/java/com/linkedin/paldb/impl/StorageReader.java
+++ b/paldb/src/main/java/com/linkedin/paldb/impl/StorageReader.java
@@ -87,6 +87,8 @@ public class StorageReader implements Iterable<Map.Entry<byte[], byte[]>> {
   private final DataInputOutput sizeBuffer = new DataInputOutput(new byte[5]);
   private final byte[] slotBuffer;
 
+  private final HashUtils hashUtils;
+
   StorageReader(Configuration configuration, File file)
       throws IOException {
     path = file;
@@ -98,6 +100,8 @@ public class StorageReader implements Iterable<Map.Entry<byte[], byte[]>> {
 
     //Config
     segmentSize = config.getLong(Configuration.MMAP_SEGMENT_SIZE);
+
+    hashUtils = new HashUtils();
 
     // Check valid segmentSize
     if (segmentSize > Integer.MAX_VALUE) {
@@ -242,7 +246,7 @@ public class StorageReader implements Iterable<Map.Entry<byte[], byte[]>> {
     if (keyLength >= slots.length || keyCounts[keyLength] == 0) {
       return null;
     }
-    long hash = (long) HashUtils.hash(key);
+    long hash = (long) hashUtils.hash(key);
     int numSlots = slots[keyLength];
     int slotSize = slotSizes[keyLength];
     int indexOffset = indexOffsets[keyLength];

--- a/paldb/src/main/java/com/linkedin/paldb/impl/StorageWriter.java
+++ b/paldb/src/main/java/com/linkedin/paldb/impl/StorageWriter.java
@@ -73,6 +73,8 @@ public class StorageWriter {
   // Number of collisions
   private int collisions;
 
+  private HashUtils hashUtils;
+
   StorageWriter(Configuration configuration, OutputStream stream) {
     config = configuration;
     loadFactor = config.getDouble(Configuration.LOAD_FACTOR);
@@ -94,6 +96,7 @@ public class StorageWriter {
     dataLengths = new long[0];
     maxOffsetLengths = new int[0];
     keyCounts = new int[0];
+    hashUtils = new HashUtils();
   }
 
   public void put(byte[] key, byte[] value)
@@ -300,7 +303,7 @@ public class StorageWriter {
           long offset = LongPacker.unpackLong(tempIndexStream);
 
           // Hash
-          long hash = (long) HashUtils.hash(keyBuffer);
+          long hash = (long) hashUtils.hash(keyBuffer);
 
           boolean collision = false;
           for (int probe = 0; probe < count; probe++) {

--- a/paldb/src/main/java/com/linkedin/paldb/utils/HashUtils.java
+++ b/paldb/src/main/java/com/linkedin/paldb/utils/HashUtils.java
@@ -23,12 +23,7 @@ import java.util.zip.Checksum;
 public class HashUtils {
 
   // Hash implementation
-  private static final Murmur3A hash = new Murmur3A(42);
-
-  // Default constructor
-  private HashUtils() {
-
-  }
+  private final Murmur3A hash = new Murmur3A(42);
 
   /**
    * Returns the positive hash for the given <code>bytes</code>.
@@ -36,7 +31,7 @@ public class HashUtils {
    * @param bytes bytes to hash
    * @return hash
    */
-  public static int hash(byte[] bytes) {
+  public int hash(byte[] bytes) {
     hash.reset();
     hash.update(bytes);
     return hash.getIntValue() & 0x7fffffff;

--- a/paldb/src/test/java/com/linkedin/paldb/utils/TestHashUtils.java
+++ b/paldb/src/test/java/com/linkedin/paldb/utils/TestHashUtils.java
@@ -19,14 +19,15 @@ import org.testng.annotations.Test;
 
 
 public class TestHashUtils {
+  HashUtils hashUtils = new HashUtils();
 
   @Test
   public void testHashEquals() {
-    Assert.assertEquals(HashUtils.hash("foo".getBytes()), HashUtils.hash("foo".getBytes()));
+    Assert.assertEquals(hashUtils.hash("foo".getBytes()), hashUtils.hash("foo".getBytes()));
   }
 
   @Test
   public void testEmpty() {
-    Assert.assertTrue(HashUtils.hash(new byte[0]) > 0);
+    Assert.assertTrue(hashUtils.hash(new byte[0]) > 0);
   }
 }


### PR DESCRIPTION
HashUtils was shared between PalDb instances. This caused errors when using multiple instances concurrently because of simultanious usage of Murmur3A. 